### PR TITLE
;

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,7 +99,7 @@ AS_IF([test "$python" != no], [
 AC_LANG_PUSH([C++])
 
 # unconditional c++11
-CXXFLAGS="$CXXFLAGS -std=c++11"
+CXXFLAGS="$CXXFLAGS -std=c++11 -pedantic"
 
 have_gala=no
 

--- a/pytdlib/python_tdlib.cpp
+++ b/pytdlib/python_tdlib.cpp
@@ -32,7 +32,7 @@
 // typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, treedec::bag_t> TD_tree_dec_t;
 // REGISTER_GRAPH_WITH_BUNDLED_BAGS(TD_tree_dec_t, bag)
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS, treedec::bag_t> TD_tree_dec_directed_t;
-REGISTER_GRAPH_WITH_BUNDLED_BAGS(TD_tree_dec_directed_t, bag)
+REGISTER_GRAPH_WITH_BUNDLED_BAGS(TD_tree_dec_directed_t, bag);
 
 #include "generic_base.hpp"
 #include "graph.hpp"

--- a/src/graph_traits.hpp
+++ b/src/graph_traits.hpp
@@ -292,11 +292,11 @@ struct graph_helper{
 	template<class S>
 	static void close_neighbourhood(S&, G const&){
 		static_assert(sizeof(S)==0, "need specialization");
-	};
+	}
 	template<class S>
 	static void open_neighbourhood(S&, G const&){
 		static_assert(sizeof(S)==0, "need specialization");
-	};
+	}
 };
 
 

--- a/src/treedec_traits.hpp
+++ b/src/treedec_traits.hpp
@@ -189,8 +189,9 @@ struct treedec_traits<T>{ \
     typedef typename T::vertex_property_type vertex_property_type; \
     typedef typename boost::bagstuff::gtob<T>::type bag_type; \
     typedef typename boost::bagstuff::gtob<T>::type::value_type vd_type; \
-}; \
-} // treedec
+}; /* treedec */ \
+} \
+void TDLIB_DUMMY_FUNCTION_DECLARATION(void) /* a dummy function declaration to require a ';' after the macro invokation */
 
 #endif
 // vim:ts=8:sw=4:et


### PR DESCRIPTION
The use of ';' has been fixed: ';' has been removed where it is not allowed (allowed by GCC extensions, but not the standard).
The macro REGISTER_GRAPH_WITH_BUNDLED_BAGS has been changed so that a ';' is required at invocations.
-pedantic has been added to the compiler flags to make GCC warn about future ';'-mistakes.

Philipp
