### PR TITLE
Rename to treedec

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([tdlib], [0.8.7], [larisch.larisch@kaust.edu.sa,felix@salfelder.org])
+AC_INIT([treedec], [0.8.8], [larisch.larisch@kaust.edu.sa,felix@salfelder.org])
 AC_CONFIG_SRCDIR([src/graph_traits.hpp])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
We have discussed the name change, there seemed to be consensus on treedec, the macros have already been renamed. So let's rename it now.

Philipp
