### PR TITLE
Fix a few leftovers from the tdlib->treedec name change in documentation and examples

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-tdlib provides tree decomposition algorithms
+treedec provides tree decomposition algorithms
 
 A tree decomposition of a simple loopless graph G is a tree T with bags at its
 nodes containing vertices from G. The usual conditions apply. By convention,
@@ -74,7 +74,7 @@ accessible e.g. using a property tag such as treedec::root_t (or similar).
 
 a possible model is
 
-#include <tdlib/treedec_traits>
+#include <treedec/treedec_traits>
 typedef std::vector<vertex_descriptor> bag_container_type;
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
         boost::property<treedec::bag_t, bag_container_type> > T;
@@ -91,7 +91,7 @@ struct mybundle{
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
                               mybundle> my_td_type;
 
-you can make bags accessible from tdlib using
+you can make bags accessible from treedec using
 
 TREEDEC_TREEDEC_BAG_TRAITS(my_td_type, bag);
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -79,14 +79,14 @@ $(GRTDP_AMNAME).gcda: $(PROFILE_GRAPH) tdecomp-profile
 		td-validate $< $(PROFILE_GRAPH).td$$i || : ; \
 	done
 
-BUILT_SOURCES = tdlib
+BUILT_SOURCES = treedec
 CLEANFILES = \
 	${BUILT_SOURCES} *~ \
    $(TWEXP_AMNAME).gcda \
 	$(GRTDP_AMNAME).gcda \
 	HoffmanGraph.gr.td*
 
-tdlib:
+treedec:
 	-$(LN_S) $(top_srcdir)/src $@
 
 #here?

--- a/examples/twthread.hpp
+++ b/examples/twthread.hpp
@@ -25,8 +25,7 @@
 #include <boost/thread.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <gala/trace.h>
-#include <tdlib/message.hpp>
-// #include <tdlib/elimination_orderings.hpp>
+#include <treedec/message.hpp>
 #include <mutex>
 #include <atomic>
 #include <condition_variable>
@@ -35,8 +34,7 @@
 #include <sys/types.h>
 #include <signal.h>
 
-#include <tdlib/timer.hpp>
-// #include <tdlib/printer.hpp>
+#include <treedec/timer.hpp>
 
 #ifdef NDEBUG
 #define assert_permutation(P)
@@ -109,7 +107,7 @@ extern std::atomic<unsigned> global_result;
  * - to handle TWTHREAD::print_results call from main thread
  */
 
-#include <tdlib/algo.hpp>
+#include <treedec/algo.hpp>
 namespace treedec{
 
 namespace draft{


### PR DESCRIPTION
In a few places the old name was still in use.

Philipp
