### PR TITLE
Replace obsolete stx-btree with tlx.

### DIFF
--- a/TODO
+++ b/TODO
@@ -18,5 +18,5 @@
 - (squashen vom overlay)
 
 -use range(.) instead of list of vertices [0..]
--stx dependency needs to be fixed
+-tlx dependency needs to be fixed
 -td-validate dependency needs to be fixed

--- a/configure.ac
+++ b/configure.ac
@@ -121,7 +121,7 @@ AS_IF([test "x$with_gala" != xno], [
 
 AM_CONDITIONAL([USE_GALA], [test $have_gala = yes])
 
-AC_CHECK_HEADERS([stx/btree_set.h])
+AC_CHECK_HEADERS([tlx/container/btree_set.hpp])
 AC_LANG_POP([C++])
 
 # BUG: in auto mode disable python if there are no headers...

--- a/src/container.hpp
+++ b/src/container.hpp
@@ -23,8 +23,8 @@
 // #include "config.h" // not yet
 #include "container_traits.hpp"
 
-#ifdef HAVE_STX_BTREE_SET_H
-#include <stx/btree_set>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+#include <tlx/container/btree_set.hpp>
 #endif
 
 namespace treedec{

--- a/src/degree.hpp
+++ b/src/degree.hpp
@@ -39,7 +39,7 @@
 
 // #if __cplusplus >= 201103L
 // # include <unordered_set>
-// #include <stx/btree_set>
+// #include <tlx/container/btree_set>
 // #endif
 
 #include "platform.hpp"
@@ -47,8 +47,8 @@
 
 #include <stack>
 
-#ifdef HAVE_STX_BTREE_SET_H
-# include <stx/btree_set>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+# include <tlx/container/btree_set.hpp>
 #endif
 
 

--- a/src/exact_cutset.hpp
+++ b/src/exact_cutset.hpp
@@ -43,8 +43,8 @@
 #include "overlay.hpp"
 #include "container_traits.hpp"
 
-#ifdef HAVE_STX_BTREE_SET_H
-#include <stx/btree_set>
+#ifdef HAVE_TLX_CONTAINER_BTREE_SET_HPP
+#include <tlx/container/btree_set.hpp>
 #endif
 
 #include <boost/container/flat_set.hpp>


### PR DESCRIPTION
The stx-btree page says that the project is obsolete, and tlx should be used instead.