### PR TITLE
Use size_t for type of v argument to put

### DIFF
--- a/src/printer.hpp
+++ b/src/printer.hpp
@@ -299,8 +299,7 @@ namespace boost{
 
 	template<class G, class U>
 	void put(boost::property_map<treedec::grtdprinter<G>, vertex_all_t>& m,
-		 	long unsigned int& v,
-			property<treedec::bag_t, std::vector<U> > const& p)
+		 size_t v, property<treedec::bag_t, std::vector<U> > const& p)
 	{
 		auto& b=bag(v, m._g);
 		for(auto i : p.m_value){


### PR DESCRIPTION
On 32-bit Linux systems, compilation fails like this:
```
/usr/include/boost/graph/copy.hpp: In instantiation of 'void boost::detail::vertex_copier<Graph1, Graph2>::operator()(const Vertex1&, Vertex2&) const [with Vertex1 = unsigned int; Vertex2 = unsigned int; Graph1 = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::property<treedec::bag_t, std::vector<short unsigned int> > >; Graph2 = treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> >]':
/usr/include/boost/graph/copy.hpp:189:28:   required from 'static void boost::detail::copy_graph_impl<0>::apply(const Graph&, MutableGraph&, CopyVertex, CopyEdge, Orig2CopyVertexIndexMap, IndexMap) [with Graph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::property<treedec::bag_t, std::vector<short unsigned int> > >; MutableGraph = treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> >; CopyVertex = boost::detail::vertex_copier<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::property<treedec::bag_t, std::vector<short unsigned int> > >, treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> > >; CopyEdge = boost::detail::edge_copier<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::property<treedec::bag_t, std::vector<short unsigned int> > >, treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> > >; IndexMap = boost::vec_adj_list_vertex_id_map<boost::property<treedec::bag_t, std::vector<short unsigned int> >, unsigned int>; Orig2CopyVertexIndexMap = boost::iterator_property_map<__gnu_cxx::__normal_iterator<unsigned int*, std::vector<unsigned int> >, boost::vec_adj_list_vertex_id_map<boost::property<treedec::bag_t, std::vector<short unsigned int> >, unsigned int>, unsigned int, unsigned int&>]'
/usr/include/boost/graph/copy.hpp:398:21:   required from 'void boost::copy_graph(const VertexListGraph&, MutableGraph&) [with VertexListGraph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, boost::property<treedec::bag_t, std::vector<short unsigned int> > >; MutableGraph = treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> >]'
bmd_thread.h:71:23:   required from 'void BMD_THREAD<G, cfgt>::do_print_results(std::ostream&) [with G = gala::graph<std::vector, std::vector, unsigned int, uvv_config>; cfgt = grtd_algo_config; std::ostream = std::basic_ostream<char>]'
bmd_thread.h:49:10:   required from here
/usr/include/boost/graph/copy.hpp:149:16: error: no matching function for call to 'put(boost::property_map<treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> >, boost::vertex_all_t, void>::type&, unsigned int&, const boost::property<treedec::bag_t, std::vector<short unsigned int> >&)'
  149 |             put(vertex_all_map2, v2, get(vertex_all_map1, v1));
      |             ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/boost/graph/graphviz.hpp:19,
                 from tdecomp.cc:22:
/usr/include/boost/property_map/property_map.hpp:126:15: note: candidate: 'template<class T, class V> void put(T*, std::ptrdiff_t, const V&)'
  126 |   inline void put(T* pa, std::ptrdiff_t k, const V& val) { pa[k] = val;  }
      |               ^~~
/usr/include/boost/property_map/property_map.hpp:126:15: note:   template argument deduction/substitution failed:
In file included from ./treedec/preprocessing.hpp:53,
                 from ./treedec/combinations.hpp:51,
                 from twh.h:102,
                 from tdecomp.cc:53:
/usr/include/boost/graph/copy.hpp:149:16: note:   mismatched types 'T*' and 'boost::property_map<treedec::draft::printer<gala::graph<std::vector, std::vector, unsigned int, uvv_config> >, boost::vertex_all_t, void>'
  149 |             put(vertex_all_map2, v2, get(vertex_all_map1, v1));
      |             ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The issue is that `unsigned int` values are 32-bit, and `unsigned long int` values are 64-bit, so a reference to a variable of the former type cannot be passed to a reference parameter of the latter type.  There is no need for that parameter to be a reference, so this patch changes to pass by value, thereby permitting type promotion.  Also, the `v` argument really needs to be of type `size_t`, since it is passed as the first argument of `bag()`.  Finally, I reformatted the parameter list to match the following 2 definitions of `put`.